### PR TITLE
Added error stack trace to console output

### DIFF
--- a/bin/s3-deploy-dotenv.js
+++ b/bin/s3-deploy-dotenv.js
@@ -44,7 +44,7 @@ deploy.on('start', function (options) {
 });
 
 deploy.on('error', function (err) {
-    console.log('\nError: ' + err);
+    console.log('\nError: ' + err + err.stack);
 });
 
 deploy.on('upload', function (file, percent, details) {


### PR DESCRIPTION
Otherwise there's no way to know what happened from something like `Error: NetworkingError: read ECONNRESET`